### PR TITLE
Crossplatform edits

### DIFF
--- a/barnold for blender 2.79b/barnold/engine/__init__.py
+++ b/barnold for blender 2.79b/barnold/engine/__init__.py
@@ -19,7 +19,7 @@ import bpy
 import bgl
 from mathutils import Matrix, Vector, geometry
 
-sys.path.append(r"C:\Program Files\Blender Foundation\Blender\2.79\scripts\modules\Arnold-5.2.0.0-windows\python")
+sys.path.append(os.path.join(os.environ["ARNOLD_HOME"],"python"))
 import arnold
 
 from ..nodes import (
@@ -105,7 +105,7 @@ def _AiNode(node, prefix, nodes):
 
 class Shaders:
     def __init__(self, data):
-        print("LOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOL")
+        print("Shader Init")
         self._data = data
 
         self._shaders = {}
@@ -136,7 +136,7 @@ class Shaders:
 
     def _export(self, mat):
         if mat.use_nodes:
-            print("SHEEENOOONAANAA")
+            print("Exporting")
             for n in mat.node_tree.nodes:
                 if isinstance(n, ArnoldNodeOutput) and n.is_active:
                     input = n.inputs[0]
@@ -270,7 +270,7 @@ class Shaders:
 
 
 def _AiPolymesh(mesh, shaders):
-    print("YEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE")
+    print("AiPolymesh triggered")
     pc = time.perf_counter()
 
     verts = mesh.vertices
@@ -514,7 +514,7 @@ def _export(data, scene, camera, xres, yres, session=None):
     duplicators = []
     duplicator_parent = False
 
-    print("NEEEEENEEEENEEEEEEENEEEENEEEEEEEEE")
+    # print("NEEEEENEEEENEEEEEEENEEEENEEEEEEEEE")
     shaders = Shaders(data)
 
     opts = scene.arnold
@@ -591,7 +591,7 @@ def _export(data, scene, camera, xres, yres, session=None):
 
             with _Mesh(ob) as mesh:
                 if mesh is not None:
-                    print("NEVERRRRRRRRRRRRRRRRRRRRR")
+                    # print("NEVERRRRRRRRRRRRRRRRRRRRR")
                     node = _AiPolymesh(mesh, shaders)
                     arnold.AiNodeSetStr(node, "name", name)
                     arnold.AiNodeSetMatrix(node, "matrix", _AiMatrix(ob.matrix_world))
@@ -959,7 +959,7 @@ def _export(data, scene, camera, xres, yres, session=None):
         session["display"] = display
         session["offset"] = xoff, yoff
         if opts.progressive_refinement:
-            print("YOU HAVE CHOOSEN TO BE PROGRESSIVE! WOO!")
+            # print("YOU HAVE CHOOSEN TO BE PROGRESSIVE! WOO!")
             isl = opts.initial_sampling_level
             session["ipr"] = (isl, AA_samples + 1)
             AA_samples = isl
@@ -978,7 +978,7 @@ def export_ass(data, scene, camera, xres, yres, filepath, open_procs, binary):
 
 
 def update(engine, data, scene):
-    print("LAUGHLAUGHLAUGH")
+    print("Arnold Engine Updating...")
     engine.use_highlight_tiles = True
     engine._session = {}
     arnold.AiBegin()

--- a/barnold for blender 2.79b/barnold/engine/ipr.py
+++ b/barnold for blender 2.79b/barnold/engine/ipr.py
@@ -6,6 +6,7 @@ __email__ = "nildar@users.sourceforge.net"
 import sys
 import numpy
 import mmap
+import platform
 
 ABORT = 1
 UPDATE = 2
@@ -133,10 +134,17 @@ def _worker(data, new_data, redraw_event, mmap_size, mmap_name, state):
 
         del nodes, nptrs, links, data
 
-        _rect = lambda n, w, h: numpy.frombuffer(
-            mmap.mmap(-1, w * h * 4 * 4, n), dtype=numpy.float32
-        ).reshape([h, w, 4])
-        rect = _rect(mmap_name, *mmap_size)
+        if platform.system() == "Darwin" or "Linux":
+            _rect = lambda w, h: numpy.frombuffer(
+                mmap.mmap(-1, w * h * 4 * 4), dtype=numpy.float32
+            ).reshape([h, w, 4])
+            rect = _rect(*mmap_size)
+
+        if platform.system() == "Windows":
+            _rect = lambda n, w, h: numpy.frombuffer(
+                mmap.mmap(-1, w * h * 4 * 4, n), dtype=numpy.float32
+            ).reshape([h, w, 4])
+            rect = _rect(mmap_name, *mmap_size)
 
         def _callback(x, y, width, height, buffer, data):
             #print("+++ _callback:", x, y, width, height, ctypes.cast(buffer, ctypes.c_void_p))
@@ -225,7 +233,12 @@ def _main():
     global _engine_, _data_, _width_, _height_, _mmap_size_, _mmap_
 
     _mmap_name = "blender/barnold/ipr/pid-%d" % id(_engine_)
-    _mmap_ = mmap.mmap(-1, 64 * 1024 * 1024, _mmap_name)  # 64Mb
+
+    if platform.system() == "Darwin" or "Linux":
+        _mmap_ = mmap.mmap(-1, 64 * 1024 * 1024)  # 64Mb
+
+    if platform.system() == "Windows":
+        _mmap_ = mmap.mmap(-1, 64 * 1024 * 1024, _mmap_name)  # 64Mb
 
     state = _mp.Value('i', 0)
     redraw_event = _mp.Event()
@@ -248,7 +261,13 @@ def _main():
         else:
             w = _width_
             h = _height_
-        _mmap_ = mmap.mmap(-1, w * h * 4 * 4, _mmap_name)
+
+        if platform.system() == "Darwin" or "Linux":
+            _mmap_ = mmap.mmap(-1, w * h * 4 * 4)
+
+        if platform.system() == "Windows":
+            _mmap_ = mmap.mmap(-1, w * h * 4 * 4, _mmap_name)
+
         opts['xres'] = ('INT', w)
         opts['yres'] = ('INT', h)
         return w, h

--- a/driver_display_callback/CMakeLists.txt
+++ b/driver_display_callback/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.5)
+project(barnold_display_callback)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+#set(CMAKE_BUILD_TYPE DEBUG)
+set(CMAKE_BUILD_TYPE RELEASE)
+
+set(SOURCE_FILES
+    src/driver_display_callback.cpp
+    )
+
+# Sorry, this is hardcoded
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules/")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC -Wno-narrowing")
+
+find_package(Arnold REQUIRED)
+
+get_filename_component(ArnLib ${ARNOLD_LIBRARIES} DIRECTORY )
+message(${ArnLib})
+
+include_directories(${ARNOLD_INCLUDE_DIRS})
+link_directories(${ArnLib})
+
+add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
+target_link_libraries(${PROJECT_NAME} ${ARNOLD_LIBRARIES})
+
+

--- a/driver_display_callback/build_osx.sh
+++ b/driver_display_callback/build_osx.sh
@@ -1,0 +1,11 @@
+# ARNOLD_HOME needs to be set for CMake to find the proper files for building.
+
+if [ -d build ]; then
+	echo "Removing existing build";
+	RM -rf build;
+fi
+
+mkdir -p build;
+cd build;
+cmake .. -G "CodeBlocks - Unix Makefiles"
+make -j

--- a/driver_display_callback/cmake/modules/FindArnold.cmake
+++ b/driver_display_callback/cmake/modules/FindArnold.cmake
@@ -1,0 +1,229 @@
+# - Arnold finder module
+# This module searches for a valid Arnold installation, by looking at
+# the Arnold_HOME environment variable. For backward compatibility reasons
+# we also support ARNOLD_HOME.
+#
+# Variables that will be defined:
+# ARNOLD_FOUND              Defined if a Arnold installation has been detected
+# ARNOLD_LIBRARY            Path to ai library (for backward compatibility)
+# ARNOLD_LIBRARIES          Path to ai library
+# ARNOLD_INCLUDE_DIR        Path to the include directory (for backward compatibility)
+# ARNOLD_INCLUDE_DIRS       Path to the include directory
+# ARNOLD_KICK               Path to kick
+# ARNOLD_PYKICK             Path to pykick
+# ARNOLD_MAKETX             Path to maketx
+# ARNOLD_OSLC               Path to the osl compiler
+# ARNOLD_OSL_HEADER_DIR     Path to the osl headers include directory (for backward compatibility)
+# ARNOLD_OSL_HEADER_DIRS    Path to the osl headers include directory
+# ARNOLD_VERSION_ARCH_NUM   Arch version of Arnold
+# ARNOLD_VERSION_MAJOR_NUM  Major version of Arnold
+# ARNOLD_VERSION_MINOR_NUM  Minor version of Arnold
+# ARNOLD_VERSION_FIX        Fix version of Arnold
+# ARNOLD_VERSION            Version of Arnold
+# arnold_compile_osl        Function to compile / install .osl files
+#   QUIET                   Quiet builds
+#   VERBOSE                 Verbose builds
+#   INSTALL                 Install compiled files into DESTINATION
+#   INSTALL_SOURCES         Install sources into DESTINATION_SOURCES
+#   OSLC_FLAGS              Extra flags for OSLC
+#   DESTINATION             Destination for compiled files
+#   DESTINATION_SOURCES     Destination for source files
+#   INCLUDES                Include directories for oslc
+#   SOURCES                 Source osl files
+#
+#
+# Naming convention:
+#  Local variables of the form _arnold_foo
+#  Input variables from CMake of the form ARNOLD_FOO
+#  Output variables of the form ARNOLD_FOO
+#
+
+find_library(ARNOLD_LIBRARY
+    NAMES ai
+    HINTS
+        "${Arnold_HOME}"
+        "$ENV{Arnold_HOME}"
+        "${ARNOLD_HOME}"
+        "$ENV{ARNOLD_HOME}"
+    PATH_SUFFIXES
+        bin/
+    DOC "Arnold library")
+
+find_file(ARNOLD_KICK
+    names kick
+    HINTS
+        "${Arnold_HOME}"
+        "$ENV{Arnold_HOME}"
+        "${ARNOLD_HOME}"
+        "$ENV{ARNOLD_HOME}"
+    PATH_SUFFIXES
+        bin/
+    DOC "Arnold kick executable")
+
+find_file(ARNOLD_PYKICK
+    names pykick
+    HINTS
+        "${Arnold_HOME}"
+        "$ENV{Arnold_HOME}"
+        "${ARNOLD_HOME}"
+        "$ENV{ARNOLD_HOME}"
+    PATH_SUFFIXES
+        bin/
+    DOC "Arnold pykick executable")
+
+find_file(ARNOLD_MAKETX
+    names maketx
+    HINTS
+        "${Arnold_HOME}"
+        "$ENV{Arnold_HOME}"
+        "${ARNOLD_HOME}"
+        "$ENV{ARNOLD_HOME}"
+    PATH_SUFFIXES
+        bin/
+    DOC "Arnold maketx executable")
+
+find_path(ARNOLD_INCLUDE_DIR ai.h
+    HINTS
+        "${Arnold_HOME}"
+        "$ENV{Arnold_HOME}"
+        "${ARNOLD_HOME}"
+        "$ENV{ARNOLD_HOME}"
+    PATH_SUFFIXES
+        include/
+    DOC "Arnold include path")
+
+find_path(ARNOLD_PYTHON_DIR arnold/ai_allocate.py
+    HINTS
+        "${Arnold_HOME}"
+        "$ENV{Arnold_HOME}"
+        "${ARNOLD_HOME}"
+        "$ENV{ARNOLD_HOME}"
+    PATH_SUFFIXES
+        python/
+    DOC "Arnold python bindings path")
+
+find_file(ARNOLD_OSLC
+    names oslc
+    HINTS
+        "${Arnold_HOME}"
+        "$ENV{Arnold_HOME}"
+        "${ARNOLD_HOME}"
+        "$ENV{ARNOLD_HOME}"
+    PATH_SUFFIXES
+        bin/
+    DOC "Arnold flavoured oslc")
+
+find_path(ARNOLD_OSL_HEADER_DIR stdosl.h
+    HINTS
+        "${Arnold_HOME}"
+        "$ENV{Arnold_HOME}"
+        "${ARNOLD_HOME}"
+        "$ENV{ARNOLD_HOME}"
+    PATH_SUFFIXES
+        osl/include/
+    DOC "Arnold flavoured osl headers")
+
+set(ARNOLD_LIBRARIES ${ARNOLD_LIBRARY})
+set(ARNOLD_INCLUDE_DIRS ${ARNOLD_INCLUDE_DIR})
+set(ARNOLD_PYTHON_DIRS ${ARNOLD_PYTHON_DIR})
+set(ARNOLD_OSL_HEADER_DIRS ${ARNOLD_OSL_HEADER_DIR})
+
+if(ARNOLD_INCLUDE_DIR AND EXISTS "${ARNOLD_INCLUDE_DIR}/ai_version.h")
+    foreach(_arnold_comp ARCH_NUM MAJOR_NUM MINOR_NUM FIX)
+        file(STRINGS
+            ${ARNOLD_INCLUDE_DIR}/ai_version.h
+            _arnold_tmp
+            REGEX "#define AI_VERSION_${_arnold_comp} .*$")
+        string(REGEX MATCHALL "[0-9]+" ARNOLD_VERSION_${_arnold_comp} ${_arnold_tmp})
+    endforeach()
+    set(ARNOLD_VERSION ${ARNOLD_VERSION_ARCH_NUM}.${ARNOLD_VERSION_MAJOR_NUM}.${ARNOLD_VERSION_MINOR_NUM}.${ARNOLD_VERSION_FIX})
+endif()
+
+function(arnold_compile_osl)
+    set(_arnold_options QUIET VERBOSE INSTALL INSTALL_SOURCES)
+    set(_arnold_one_value_args OSLC_FLAGS DESTINATION DESTINATION_SOURCES)
+    set(_arnold_multi_value_args INCLUDES SOURCES)
+    cmake_parse_arguments(arnold_compile_osl "${_arnold_options}" "${_arnold_one_value_args}" "${_arnold_multi_value_args}" ${ARGN})
+
+    if(CMAKE_BUILD_TYPE MATCHES Debug)
+        set(_arnold_oslc_opt_flags "-d -O0")
+    elseif(CMAKE_BUILD_TYPE MATCHES Release)
+        set(_arnold_oslc_opt_flags "-O2")
+    elseif(CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
+        set(_arnold_oslc_opt_flags "-d -O2")
+    else()
+        set(_arnold_oslc_opt_flags "-O2")
+    endif()
+
+    set(_arnold_oslc_flags "-I${ARNOLD_OSL_HEADER_DIR}")
+    set(_arnold_oslc_flags "${_arnold_oslc_flags} ${arnold_compile_osl_OSLC_FLAGS}")
+    if(${arnold_compile_osl_QUIET})
+        set(_arnold_oslc_flags "${_arnold_oslc_flags} -q")
+    endif()
+
+    if(${arnold_compile_osl_VERBOSE})
+        set(_arnold_oslc_flags "${_arnold_oslc_flags} -v")
+    endif()
+
+    foreach(_arnold_include ${arnold_compile_osl_INCLUDES})
+        set(_arnold_oslc_flags "${_arnold_oslc_flags} -I${_arnold_include}")
+    endforeach()
+
+    set(_arnold_oslc_flags "${_arnold_oslc_flags} ${_arnold_oslc_opt_flags}")
+    if(${arnold_compile_osl_VERBOSE})
+        message (STATUS "OSL - Arnold compile options : ${_arnold_oslc_flags}")
+    endif()
+
+    foreach(_arnold_source ${arnold_compile_osl_SOURCES})
+        # unique name for each target
+        string(REPLACE ".osl" ".oso" _arnold_target_name ${_arnold_source})
+        string(REPLACE "/" "_" _arnold_target_name ${_arnold_target_name})
+        string(REPLACE "\\" "_" _arnold_target_name ${_arnold_target_name})
+        string(REPLACE ":" "_" _arnold_target_name ${_arnold_target_name})
+        set(_arnold_target_path "${CMAKE_CURRENT_BINARY_DIR}/${_arnold_target_name}")
+        string(REPLACE "." "_" _arnold_target_name ${_arnold_target_name})
+        set(_arnold_cmd_args "${_arnold_oslc_flags} -o ${_arnold_target_path} ${_arnold_source}")
+        separate_arguments(_arnold_cmd_args)
+        add_custom_command(OUTPUT ${_arnold_target_path}
+                           COMMAND ${ARNOLD_OSLC} ${_arnold_cmd_args}
+                           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+        add_custom_target(${_arnold_target_name} ALL
+                          DEPENDS ${_arnold_target_path}
+                          SOURCES ${_arnold_source})
+        if(${arnold_compile_osl_INSTALL})
+            get_filename_component(_arnold_install_name ${_arnold_source} NAME)
+            # rename the unique files
+            string(REPLACE ".osl" ".oso" _arnold_install_name ${_arnold_install_name})
+            install(FILES ${_arnold_target_path}
+                    DESTINATION ${arnold_compile_osl_DESTINATION}
+                    RENAME ${_arnold_install_name})
+        endif()
+        if(${arnold_compile_osl_INSTALL_SOURCES})
+            install(FILES ${_arnold_source} DESTINATION ${arnold_compile_osl_DESTINATION_SOURCES})
+        endif()
+    endforeach()
+endfunction(arnold_compile_osl)
+
+message(STATUS "Arnold library: ${ARNOLD_LIBRARY}")
+message(STATUS "Arnold headers: ${ARNOLD_INCLUDE_DIR}")
+message(STATUS "Arnold version: ${ARNOLD_VERSION}")
+
+include(FindPackageHandleStandardArgs)
+
+if(${ARNOLD_VERSION_ARCH_NUM} VERSION_GREATER "4")
+    find_package_handle_standard_args(Arnold
+        REQUIRED_VARS
+        ARNOLD_LIBRARY
+        ARNOLD_INCLUDE_DIR
+        ARNOLD_OSLC
+        ARNOLD_OSL_HEADER_DIR
+        VERSION_VAR
+        ARNOLD_VERSION)
+else()
+    find_package_handle_standard_args(Arnold
+        REQUIRED_VARS
+        ARNOLD_LIBRARY
+        ARNOLD_INCLUDE_DIR
+        VERSION_VAR
+        ARNOLD_VERSION)
+endif()

--- a/driver_display_callback/src/driver_display_callback.cpp
+++ b/driver_display_callback/src/driver_display_callback.cpp
@@ -1,0 +1,180 @@
+#include <ai.h>
+
+namespace ASTR {
+	static const AtString callback("callback");
+	static const AtString callback_data("callback_data");
+	static const AtString color_space("color_space");
+};
+
+AI_DRIVER_NODE_EXPORT_METHODS(DriverDisplayCallbackMtd)
+
+typedef void(*DisplayCallback)(uint32_t x, uint32_t y, uint32_t width, uint32_t height, uint8_t* buffer, void* data);
+
+node_parameters
+{
+	AiParameterPtr("callback"     , NULL);
+AiParameterPtr("callback_data", NULL);  // This value will be passed directly to the callback function
+}
+
+node_initialize
+{
+	AiDriverInitialize(node, false);
+}
+
+node_update
+{
+}
+
+driver_supports_pixel_type
+{
+	switch (pixel_type)
+	{
+	case AI_TYPE_FLOAT:
+	case AI_TYPE_RGB:
+	case AI_TYPE_RGBA:
+		return true;
+	default:
+		return false;
+	}
+}
+
+driver_extension
+{
+	return NULL;
+}
+
+driver_open
+{
+}
+
+driver_needs_bucket
+{
+	return true;
+}
+
+driver_prepare_bucket
+{
+	DisplayCallback cb = (DisplayCallback)AiNodeGetPtr(node, ASTR::callback);
+
+// Call the callback function with a NULL buffer pointer, to indicate
+// a bucket is going to start being rendered.
+if (cb)
+{
+	void *cb_data = AiNodeGetPtr(node, ASTR::callback_data);
+	(*cb)(bucket_xo, bucket_yo, bucket_size_x, bucket_size_y, NULL, cb_data);
+}
+}
+
+driver_write_bucket
+{
+	int pixel_type;
+const void* bucket_data;
+
+// Get the first AOV layer
+if (!AiOutputIteratorGetNext(iterator, NULL, &pixel_type, &bucket_data))
+return;
+
+const bool dither = true;
+
+// Retrieve color manager for conversion
+AtNode* color_manager = (AtNode*)AiNodeGetPtr(AiUniverseGetOptions(), "color_manager");
+AtString display_space, linear_space;
+AiColorManagerGetDefaults(color_manager, display_space, linear_space);
+if (!display_space)
+display_space = linear_space;
+
+// Allocates memory for the final pixels in the bucket
+//
+// This memory is not released here. The client code is
+// responsible for its release, which must be done using
+// the AiFree() function in the Arnold API
+uint8_t* buffer = (uint8_t*)AiMalloc(bucket_size_x * bucket_size_y * sizeof(uint8_t) * 4);
+int minx = bucket_xo;
+int miny = bucket_yo;
+int maxx = bucket_xo + bucket_size_x - 1;
+int maxy = bucket_yo + bucket_size_y - 1;
+
+for (int j = miny; (j <= maxy); ++j)
+{
+	for (int i = minx; (i <= maxx); ++i)
+	{
+		int bx = i - minx;
+		int by = j - miny;
+		AtRGBA source = AI_RGBA_ZERO;
+
+		switch (pixel_type)
+		{
+		case AI_TYPE_FLOAT:
+		{
+			float f = ((float*)bucket_data)[by * bucket_size_x + bx];
+			source = AtRGBA(f, f, f, 1.0f);
+			break;
+		}
+		case AI_TYPE_RGB:
+		{
+			AtRGB rgb = ((AtRGB*)bucket_data)[by * bucket_size_x + bx];
+			source = AtRGBA(rgb, 1.0f);
+			break;
+		}
+		case AI_TYPE_RGBA:
+		{
+			source = ((AtRGBA*)bucket_data)[by * bucket_size_x + bx];
+			break;
+		}
+		}
+
+		AiColorManagerTransform(color_manager, display_space, false, false, NULL, (uint8_t*)&source.rgb());
+
+		uint8_t* target = &buffer[(by * bucket_size_x + bx) * 4];
+		target[0] = AiQuantize8bit(i, j, 0, source.r, dither);
+		target[1] = AiQuantize8bit(i, j, 1, source.g, dither);
+		target[2] = AiQuantize8bit(i, j, 2, source.b, dither);
+		target[3] = AiQuantize8bit(i, j, 3, source.a, dither);
+	}
+}
+
+// Sends the buffer with the final pixels to the callback for display.
+//
+// The callback receives ownership over this buffer, so it must
+// release it when it is done with it, using the AiFree() function
+// in the Arnold API.
+//
+// The reason for doing this is to decouple this code from the visualization
+// process, so, as soon as the buffer is ready, this driver will send it to
+// the callback and return to the rendering process, which will continue
+// asynchronously, in parallel with the visualization of the bucket, carried
+// out by the client code.
+//
+DisplayCallback cb = (DisplayCallback)AiNodeGetPtr(node, ASTR::callback);
+if (cb)
+{
+	void *cb_data = AiNodeGetPtr(node, ASTR::callback_data);
+	(*cb)(bucket_xo, bucket_yo, bucket_size_x, bucket_size_y, buffer, cb_data);
+}
+}
+
+driver_process_bucket
+{
+	// Use this instead of driver_write_bucket for best performance, if your
+	// callback handling code is thread safe.
+}
+
+driver_close
+{
+}
+
+node_finish
+{
+}
+
+node_loader
+{
+	if (i>0)
+	return false;
+
+node->methods = DriverDisplayCallbackMtd;
+node->name = "driver_display_callback";
+node->node_type = AI_NODE_DRIVER;
+strcpy(node->version, AI_VERSION);
+return true;
+}


### PR DESCRIPTION
Hi Tyler,

This is the edits I have made to be able to use barnold on Mac:

- **mmap** constructor is different across Unix/Win `Avoiding the use of the tag parameter will assist in keeping your code portable between Unix and Windows.` [source](https://docs.python.org/3.0/library/mmap.html)
- Use environment variable `ARNOLD_HOME` to detect Arnold's SDK automatically.
- Cleaned a few printing commands.
- Added the driver source, cmake configuration and a simple build script for OSX. 